### PR TITLE
Pagination - first draft

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "jekyll", "~> 3.6.2"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  #gem "jekyll-paginate"
+  gem "jekyll-paginate-v2"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-feed (0.9.2)
       jekyll (~> 3.3)
+    jekyll-paginate-v2 (1.9.0)
+      jekyll (~> 3.0)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
@@ -49,6 +51,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.6.2)
   jekyll-feed (~> 0.6)
+  jekyll-paginate-v2
   tzinfo-data
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -32,11 +32,24 @@ markdown: kramdown
 # theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-paginate-v2
+  #- jekyll-paginate
+  
 
 tag_page_layout: tag
 tag_page_dir: tags
 
 permalink: pretty
+
+# Pagination Settings
+pagination:
+  enabled: true
+  per_page: 5
+  permalink: '/page/:num/'
+  title: ' - page :num'
+  limit: 0
+  sort_field: 'date'
+  sort_reverse: true
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -4,8 +4,28 @@ layout: default
 {% include category_display.html %}
 <div class="container">
     <div class="text-center">
-        {% for post in site.categories[page.category] %}
+
+        {% for post in paginator.posts %}
             {% include post_display.html %}
         {% endfor %}
+        <!-- {% for post in site.categories[page.category] %}
+            {% include post_display.html %}
+        {% endfor %} -->
+
+        {% if paginator.total_pages > 1 %}
+        <ul class="pager">
+            {% if paginator.previous_page %}
+            <li class="previous">
+                <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer Posts</a>
+            </li>
+            {% endif %}
+            {% if paginator.next_page %}
+            <li class="next">
+                <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older Posts &rarr;</a>
+            </li>
+            {% endif %}
+        </ul>
+      {% endif %}
+
     </div>
 </div>

--- a/category/DE.html
+++ b/category/DE.html
@@ -1,4 +1,9 @@
 ---
 layout: category_index
+permalink: /category/DE/
 category: DE
+pagination: 
+    enabled: true
+    category: DE
+    permalink: /:num/
 ---

--- a/category/EN.html
+++ b/category/EN.html
@@ -1,4 +1,9 @@
 ---
 layout: category_index
+permalink: /category/EN/
 category: EN
+pagination: 
+    enabled: true
+    category: EN
+    permalink: /:num/
 ---

--- a/category/HI.html
+++ b/category/HI.html
@@ -1,4 +1,9 @@
 ---
 layout: category_index
+permalink: /category/HI/
 category: HI
+pagination: 
+    enabled: true
+    category: HI
+    permalink: /:num/
 ---


### PR DESCRIPTION
Here's a first attempt on the pagination.

It seems to work ok, I've got it set to paginate at 5 just so you can see it.

It uses the newer plugin that supports categories which is referenced on the Jekyll - Pagination refenrece page.  So make sure to use that repo as reference: https://github.com/sverrirs/jekyll-paginate-v2


Here are some of the examples for how  to set it up: https://github.com/sverrirs/jekyll-paginate-v2/tree/master/examples

I used the example for categories: https://github.com/sverrirs/jekyll-paginate-v2/tree/master/examples/02-category

One thing i don't like is that it doesn't show how many pages there are and doesn't allow you to jump between pages like `<<Previous 1, 2, 3, 4 >>` Next it's more like the  `<Previous Next>` currently.  But that's not to say it can't be changed I just ran out of time.

Also another thing I don't like is that the `<previous and next>` buttons link to `/category/en/2/index.html` rather than `/category/en/2` but anyways it's a start!